### PR TITLE
Checkbox doesn't have a default value and so can't show whether checked or not

### DIFF
--- a/core/components/formitfastpack/elements/chunks/fieldtypestpl.chunk.tpl
+++ b/core/components/formitfastpack/elements/chunks/fieldtypestpl.chunk.tpl
@@ -16,7 +16,7 @@
 
 <!-- checkbox -->
 <span class="boolWrap[[+error_class]]">
-<input name="[[+name]][[+array:notempty=`[]`]]" type="hidden" value="" />
+<input name="[[+name]][[+array:notempty=`[]`]]" type="hidden" value="[[+current_value:default=`[[+default]]`]]" />
 [[+options_html]]
 </span>
 <!-- checkbox -->


### PR DESCRIPTION
From what I could see checkboxes didn't have a default value making it difficult to figure out what was going on in the admin. I've added the default value into the chunk in my fork - does this look like a good fix for the issue?
