### PR TITLE
add ability to set multiple defaults for multi-value fields

### DIFF
--- a/core/components/formitfastpack/model/formitfastpack/ffpfield.class.php
+++ b/core/components/formitfastpack/model/formitfastpack/ffpfield.class.php
@@ -365,6 +365,11 @@ class ffpField {
         }
         // use default value if not already set
         $current_value = is_null($current_value) ? $this->config['default_value'] : $current_value;
+	// support multiple default values on array fields (checkboxes) using same delimiter (format would be
+	// &default_value=`option1||option2`. don't include labels in default specification.
+	if($this->config['array'] && !is_array($current_value)) {
+            $current_value = explode($this->config['options_delimiter_outer'], $current_value);
+        }
         // if configured, save current value in session/ cookies for later use
         if ($this->config['use_session']) {
             $_SESSION[$session_key] = $current_value;


### PR DESCRIPTION
Right now, multi-value fields can't have multiple defaults set. This is problematic for checkbox fields in particular. With this patch, we check to see if the field is marked as an array field and then check to see if the current value is an array. If it isn't, then make it into one, using the options_outer_delimiter to split. 